### PR TITLE
Feat disable botao/open modal

### DIFF
--- a/src/components/atoms/FormButtonConcluir/FormButtonConcluir.module.scss
+++ b/src/components/atoms/FormButtonConcluir/FormButtonConcluir.module.scss
@@ -27,3 +27,8 @@ color: $gelo;
 border: none;
 margin: 5px;
 }
+
+.concluir:disabled{
+    cursor:not-allowed;
+    opacity:0.7;
+}

--- a/src/components/atoms/FormButtonConcluir/formButtonConcluir.jsx
+++ b/src/components/atoms/FormButtonConcluir/formButtonConcluir.jsx
@@ -1,10 +1,10 @@
 import styles from '../FormButtonConcluir/FormButtonConcluir.module.scss'
 
-export default function FormButtonConcluir(){
+export default function FormButtonConcluir({disabled}){
     return(
         <div className={styles.containerModal}>
         <div >
-            <button className={styles.concluir}
+            <button disabled={disabled}  className={styles.concluir}
             type="submit">
                 Concluir
             </button>

--- a/src/components/atoms/FormCadastro/FormInput.jsx
+++ b/src/components/atoms/FormCadastro/FormInput.jsx
@@ -1,5 +1,6 @@
 import FormButtonDescarta from "../FormButtonDescarta/formButtonDescarta";
 import FormButtonConcluir from "../FormButtonConcluir/formButtonConcluir";
+import { customStyles } from "@/utils/modalStyles";
 import Image from "next/image";
 import { Formik, Field, Form } from "formik";
 import React, { useState } from "react";
@@ -16,8 +17,10 @@ import registerSchema from "@/utils/registerSchema";
 import RadioAgree from "../RadioAgree";
 export default function FormCadastro(props) {
   const [modalIsOpen, setIsOpen] = useState(false);
-  
-  const[agree, setIsAgree] = useState(false)
+  const [modalEmail, setOpenEmail] = useState(false)
+
+  const [agree, setIsAgree] = useState(false);
+
 
   function handleOpenModal() {
     setIsOpen(true);
@@ -26,29 +29,34 @@ export default function FormCadastro(props) {
     setIsOpen(false);
   }
 
+  function handleModalEmail(){
+    setOpenEmail(true)
+  }
+  function closeModalEmail(){
+    setOpenEmail(false)
+  }
 
-  const handleSubmit = async (event) => {
-    event.preventDefault();
 
-    if (formik.isValid) {
-      try {
-        const response = await axios.post(
-          "https://mentores-backend.onrender.com/user",
-          {
-            fullName: formik.values.name,
-            email: formik.values.email,
-            dateOfBirth: formik.values.dataBirthday,
-            emailConfirm: formik.values.confirmEmail,
-            password: formik.values.password,
-            passwordConfirmation: formik.values.confirmPassword,
-          }
-        );
+  const handleSubmit = async (values, {resetForm}) => {
+    event.preventDefault()
+    try {
+      const response = await axios.post(
+        "https://mentores-backend.onrender.com/user",
+        {
+          fullName: values.name,
+          email: values.email,
+          dateOfBirth: values.dataBirthday,
+          emailConfirm: values.confirmEmail,
+          password: values.password,
+          passwordConfirmation: values.confirmPassword,
+        }
+      );
 
-        console.log(response.data);
-        console.log(formik.touched);
-      } catch (error) {
-        console.error(error);
-      }
+      console.log(response.data);
+      resetForm()
+      handleModalEmail()
+    } catch (error) {
+      console.error(error);
     }
   };
 
@@ -62,15 +70,7 @@ export default function FormCadastro(props) {
     confirmPassword: "",
   };
 
-  const customStyles = {
-    content: {
-      top: "30%",
-      left: "50%",
-      right: "auto",
-      bottom: "auto",
-      trasnform: "translate(-50%, -50%)",
-    },
-  };
+
 
   return (
     <ContainerForm>
@@ -95,7 +95,7 @@ export default function FormCadastro(props) {
               as={InputForm}
               type="text"
               name="name"
-              label='Nome completo'
+              label="Nome completo"
               placeholder="Preencha com seu nome"
             />
 
@@ -103,7 +103,7 @@ export default function FormCadastro(props) {
               as={InputForm}
               type="date"
               name="dataBirthday"
-              label='Data de nascimento'
+              label="Data de nascimento"
               placeholder="MM/DD/YYY"
             />
 
@@ -111,7 +111,7 @@ export default function FormCadastro(props) {
               as={InputForm}
               type="email"
               label="E-mail"
-              name='email'
+              name="email"
               placeholder="Preencha com o seu email"
             />
 
@@ -119,7 +119,7 @@ export default function FormCadastro(props) {
               as={InputForm}
               type="email"
               label="Confirmar E-mail"
-              name='confirmEmail'
+              name="confirmEmail"
               placeholder="Confirme seu email"
             />
 
@@ -127,7 +127,7 @@ export default function FormCadastro(props) {
               as={InputForm}
               type="password"
               label="Senha"
-              name='password'
+              name="password"
               placeholder="*******"
             />
 
@@ -135,14 +135,14 @@ export default function FormCadastro(props) {
               as={InputForm}
               type="password"
               label="Confirmar Senha"
-              name='confirmPassword'
+              name="confirmPassword"
               placeholder="******"
             />
             <ContainerTerms>
               <RadioAgree
-              checked={agree}
-              onChange={(e) => setIsAgree(e.target.checked)}
-               />
+                checked={agree}
+                onChange={(e) => setIsAgree(e.target.checked)}
+              />
               <TxtTerms className="termo">
                 Concordo com os{" "}
                 <button className="termo-button" onClick={handleOpenModal}>
@@ -165,6 +165,15 @@ export default function FormCadastro(props) {
               </Modal>
             </ContainerTerms>
             <FormButtonConcluir disabled={!agree} />
+            <Modal
+            isOpen={modalEmail}
+            onRequestClose={!handleModalEmail}
+            style={customStyles}
+            >
+              <button onClick={closeModalEmail}>X</button>
+              <h1>Modal envio email</h1>
+              <span>Aqui será o componente modal de confirmação de email!</span>
+            </Modal>
             <FormButtonDescarta />
           </Form>
         </Formik>

--- a/src/components/atoms/FormCadastro/FormInput.jsx
+++ b/src/components/atoms/FormCadastro/FormInput.jsx
@@ -13,8 +13,11 @@ import InputForm from "../InputRegister";
 import axios from "axios";
 import Modal from "react-modal";
 import registerSchema from "@/utils/registerSchema";
+import RadioAgree from "../RadioAgree";
 export default function FormCadastro(props) {
   const [modalIsOpen, setIsOpen] = useState(false);
+  
+  const[agree, setIsAgree] = useState(false)
 
   function handleOpenModal() {
     setIsOpen(true);
@@ -22,6 +25,7 @@ export default function FormCadastro(props) {
   function handleCloseModal() {
     setIsOpen(false);
   }
+
 
   const handleSubmit = async (event) => {
     event.preventDefault();
@@ -135,7 +139,10 @@ export default function FormCadastro(props) {
               placeholder="******"
             />
             <ContainerTerms>
-              <input type="radio" />
+              <RadioAgree
+              checked={agree}
+              onChange={(e) => setIsAgree(e.target.checked)}
+               />
               <TxtTerms className="termo">
                 Concordo com os{" "}
                 <button className="termo-button" onClick={handleOpenModal}>
@@ -157,7 +164,7 @@ export default function FormCadastro(props) {
                 <div>Termos de uso</div>
               </Modal>
             </ContainerTerms>
-            <FormButtonConcluir />
+            <FormButtonConcluir disabled={!agree} />
             <FormButtonDescarta />
           </Form>
         </Formik>

--- a/src/components/atoms/RadioAgree/index.jsx
+++ b/src/components/atoms/RadioAgree/index.jsx
@@ -1,0 +1,9 @@
+import { InputRadio } from "./style";
+
+export default function RadioAgree({ onChange, checked }) {
+  return (
+    <>
+      <InputRadio checked={checked} onChange={onChange} type="radio" />
+    </>
+  );
+}

--- a/src/components/atoms/RadioAgree/style.js
+++ b/src/components/atoms/RadioAgree/style.js
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+
+export const InputRadio = styled.input
+`
+ &:checked {
+    background-color:blue;
+}
+
+`

--- a/src/utils/modalStyles.js
+++ b/src/utils/modalStyles.js
@@ -1,0 +1,9 @@
+export const customStyles = {
+    content: {
+      top: "30%",
+      left: "50%",
+      right: "auto",
+      bottom: "auto",
+      trasnform: "translate(-50%, -50%)",
+    },
+  };


### PR DESCRIPTION
 **DESCRIÇÃO DA PR**
<hr>

Foi adicionado a condição de conseguir utilizar o botão de concluir somente quando o input radio dos termos e politicas de privacidade estiver checked:

<hr>

**EXEMPLO QUANDO NÃO ESTÁ CHECKED**

![image](https://github.com/SouJunior/mentores-frontend/assets/88148849/59735335-e545-4494-863b-45e9bcc73fbd)

<hr>

**EXEMPLO QUANDO ESTÁ CHECKED**

![image](https://github.com/SouJunior/mentores-frontend/assets/88148849/b6327705-4f49-444d-a675-676cc5da14f3)

<hr>

**MODAL ENVIO EMAIL**

Também, ao clicar no botão de "Concluir" e for enviados os dados a API, é aberto o modal de confirmação de email, que por enquanto é um genérico enquanto o modelo final não fica pronto:


![image](https://github.com/SouJunior/mentores-frontend/assets/88148849/e06d4b0d-1283-4d70-aa1d-5da2226fa194)


