### PR TITLE
feat: criação do CardComponent

### DIFF
--- a/src/components/atoms/CardComponent/index.jsx
+++ b/src/components/atoms/CardComponent/index.jsx
@@ -1,0 +1,27 @@
+import { Box } from "@mui/material";
+import React from "react";
+const CardComponent = ({ children, height, width, backgroundColor }) => {
+  const padrao = {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    flexDirection: "column",
+    boxShadow: "none",
+    border: "none",
+    padding: "0px",
+  };
+  return (
+    <Box
+      sx={{
+        height: height,
+        width: width,
+        backgroundColor: backgroundColor,
+        ...padrao,
+      }}
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default CardComponent;

--- a/src/components/molecules/FormRegister/FormRegister.jsx
+++ b/src/components/molecules/FormRegister/FormRegister.jsx
@@ -17,6 +17,7 @@ import {
   ContainerTerms,
   TxtTerms,
 } from "./style";
+import CardComponent from "@/components/atoms/CardComponent";
 export default function FormRegister(props) {
   const [openTermos, setOpenTermos] = useState(false);
   const [openPoliticas, setOpenPoliticas] = useState(false);
@@ -146,14 +147,14 @@ export default function FormRegister(props) {
               open={openTermos}
               onClose={handleCloseTermos}
               height={"590px"}
-			  width={'600px'}
+              width={"600px"}
             />
 
             <ModalPoliticas
               open={openPoliticas}
               onClose={handleClosePoliticas}
               height={"590px"}
-			  width={'600px'}
+              width={"600px"}
             />
 
             <ModalEmail


### PR DESCRIPTION
## :sparkles:Atualização: Componente de Card:sparkles:

:pushpin:Nesta atualização, criei um novo componente de card de forma genérica, utilizando Material UI, para melhorar a reutilização e a consistência no nosso projeto.

**:hammer:Código do componente:**
![image](https://github.com/SouJunior/mentores-frontend/assets/106066785/2277bb8f-ed58-456d-b960-b9078c87ae8e)

# :speech_balloon:OBS:
Criei a variável "padrao" para manter lá as customizações que podem se repetir na maior parte dos cards, mas essa parte é opcional, podendo futuramente ser eliminada ou editada