### PR TITLE
fix: Ajustando regra minimo 8 caracteres senha

### DIFF
--- a/src/components/atoms/InfoTooltip/index.jsx
+++ b/src/components/atoms/InfoTooltip/index.jsx
@@ -34,7 +34,7 @@ export default function InfoTooltip() {
           <Title>Sua senha deve conter:</Title>
           <Line />
           <CriteriaList>
-            <Criterion>Máximo 8 caracteres.</Criterion>
+            <Criterion>Mínimo 8 caracteres.</Criterion>
             <Criterion>Pelo menos uma letra maiúsculo.</Criterion>
             <Criterion>Pelo menos um número.</Criterion>
             <Criterion>Pelo menos um caractere especial (ex: @#$)</Criterion>

--- a/src/utils/registerSchema.js
+++ b/src/utils/registerSchema.js
@@ -17,6 +17,7 @@ export const registerSchema = yup.object({
 	password: yup
 		.string()
 		.required('A senha é obrigatória')
+		.min(8, 'Senha inválida')
 		.matches(
 			/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/,
 			'Senha inválida',


### PR DESCRIPTION
**DESCRIÇÃO DA PR**

<hr>

Foi feito a alteração em uma das regras do password. Agora o usuário precisar inserir uma senha com no mínimo 8 caracteres:

![image](https://github.com/SouJunior/mentores-frontend/assets/88148849/b02f783b-e8b6-4691-8fa1-40a17e9f86c0)

<hr>

**TOOLTIP CRITÉRIO SENHA**

Também foi alterado o texto do tooltip que mostra os critérios da senha para cadastro.

![image](https://github.com/SouJunior/mentores-frontend/assets/88148849/5ff974e4-1e45-4597-a4b6-da033f55c3a1)
