### PR TITLE
#110 Realizada alteração na tela de cadastro corrigindo botão concluir

### DIFF
--- a/src/components/molecules/FormRegister/index.jsx
+++ b/src/components/molecules/FormRegister/index.jsx
@@ -3,9 +3,9 @@ import InfoTooltip from "@/components/atoms/InfoTooltip";
 import ModalEmail from "@/components/molecules/ModalEmail";
 import { initialValues, registerSchema } from "@/utils/registerSchema";
 import axios from "axios";
-import { Field, Form, Formik } from "formik";
+import { Field, Form, FormikProvider, useFormik } from "formik";
 import Image from "next/image";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "../../atoms/Button";
 import InputForm from "../../atoms/InputForm";
 import ModalCancel from "../ModalCancel";
@@ -23,7 +23,8 @@ export default function FormRegister(props) {
   const [openTermos, setOpenTermos] = useState(false);
   const [openPoliticas, setOpenPoliticas] = useState(false);
   const [openModalCancel, setOpenModalCancel] = useState(false);
-  const [agree, setIsAgree] = useState("");
+  const [agree, setIsAgree] = useState(false);
+  const [concluidoDesabilitado, setIsConcluidoDesabilitado] = useState(true);
   const [openEmail, setOpenEmail] = useState(false);
   const [show, setShow] = useState(true);
   const [eye, setEye] = useState(true);
@@ -74,14 +75,25 @@ export default function FormRegister(props) {
     }
   };
 
+  const formik = useFormik({
+    initialValues: initialValues,
+    validationSchema: registerSchema,
+    onSubmit: handleSubmit,
+  });
+
+  useEffect(() => {
+    if (agree && formik.isValid && Object.keys(formik.touched).length > 0) {
+      setIsConcluidoDesabilitado(false)
+    } else {
+      setIsConcluidoDesabilitado(true)
+    }
+  }, [agree, formik.isValid, formik.touched]);
+  
+
   return (
     <ContainerForm>
       <ContainerCadastro>
-        <Formik
-          initialValues={initialValues}
-          validationSchema={registerSchema}
-          onSubmit={handleSubmit}
-        >
+        <FormikProvider value={formik}>
           <Form>
             <Image
               className="souj"
@@ -195,7 +207,7 @@ export default function FormRegister(props) {
               height={"730px"}
             />
             <ContainerBtn>
-              <Button btnRole={"form"} content={"Concluir"} disabled={!agree} />
+              <Button btnRole={"form"} content={"Concluir"} disabled={concluidoDesabilitado} />
 
               <Button
                 btnRole={"formSecondary"}
@@ -212,7 +224,7 @@ export default function FormRegister(props) {
               onClose={closeModalCancel}
             />
           </Form>
-        </Formik>
+        </FormikProvider>
       </ContainerCadastro>
     </ContainerForm>
   );


### PR DESCRIPTION
- [x] Feito o ajuste para que o botão "Concluir" só fique disponível quando todos os campos estiverem preenchidos e o checkbox de _termos e condições/privacidade_ estiver marcado.