### PR TITLE
AJUSTE SOMBRA DOS CARDS

### DIFF
--- a/src/components/atoms/CardComponent/index.jsx
+++ b/src/components/atoms/CardComponent/index.jsx
@@ -1,9 +1,8 @@
 import { Box } from "@mui/material";
 import React from "react";
-const CardComponent = ({ children, height, width, backgroundColor }) => {
+const CardComponent = ({ children, height, width, backgroundColor, justifyContent }) => {
   const padrao = {
     display: "flex",
-    justifyContent: "center",
     alignItems: "center",
     flexDirection: "column",
     boxShadow: "0px 4px 4px rgba(0, 0, 0, 0.25)",
@@ -21,6 +20,7 @@ const CardComponent = ({ children, height, width, backgroundColor }) => {
         height: height,
         width: width,
         backgroundColor: backgroundColor,
+        justifyContent: justifyContent,
         ...padrao,
       }}
     >

--- a/src/components/atoms/CardComponent/index.jsx
+++ b/src/components/atoms/CardComponent/index.jsx
@@ -12,7 +12,8 @@ const CardComponent = ({ children, height, width, backgroundColor }) => {
     padding: "0px",
     marginLeft: "30px",
     border: "1px solid #D7D9D7",
-    marginTop: "20px"
+    marginTop: "20px",
+    marginBottom: "15px"
   };
   return (
     <Box

--- a/src/components/molecules/CardDepo/index.jsx
+++ b/src/components/molecules/CardDepo/index.jsx
@@ -4,20 +4,23 @@ import { GreatContainer, HeaderCardDepo } from './style';
 
 export default function CardDepo({ mentor }) {
 	return (
-		<CardComponent backgroundColor={'#fdfdfd'}>
-			<GreatContainer>
-				<HeaderCardDepo>
-					<Image
-						src={mentor.image}
-						alt={mentor.name}
-						width={56}
-						height={56}
-					/>
-					<div>
-						<h4>{mentor.name}</h4>
-						<h5>{mentor.role}</h5>
-					</div>
-				</HeaderCardDepo>
+		<CardComponent 
+			backgroundColor={'#fdfdfd'} 
+			height={310} width={330} 
+			justifyContent={'flex-start'}> 
+				<GreatContainer>
+					<HeaderCardDepo>
+						<Image
+							src={mentor.image}
+							alt={mentor.name}
+							width={56}
+							height={56}
+						/>
+						<div>
+							<h4>{mentor.name}</h4>
+							<h5>{mentor.role}</h5>
+						</div>
+					</HeaderCardDepo>
 				<p>{mentor.description}</p>
 			</GreatContainer>
 		</CardComponent>


### PR DESCRIPTION
<h2>Descrição</h2>
O objetivo principal desta PR é corrigir a sombra cortada dos cards de depoimento e mentores

<h2>Mudanças</h2>
1. Adicionado margin bottom aos cards para evitar corte da sombra;
2. Ajuste no tamanho dos cads de depoimentos;
3. Adição de nova props no cardComponent (justifyContent)

<h2>Imagens</h2>

**ANTES**

![image](https://github.com/SouJunior/mentores-frontend/assets/100648619/a645396d-058b-4093-bdde-706b8f4a7590)

**DEPOIS**

![image](https://github.com/SouJunior/mentores-frontend/assets/100648619/746cb571-1f79-4a56-a35a-b252273a86b0)
![image](https://github.com/SouJunior/mentores-frontend/assets/100648619/bba5b112-4c2f-49fa-9f74-c2c6cac39d2a)