### PR TITLE
fix: ajustando erros e validações do form cadastro

### DIFF
--- a/src/components/molecules/FormRegister/index.tsx
+++ b/src/components/molecules/FormRegister/index.tsx
@@ -3,7 +3,7 @@ import { Checkbox } from "@/components/atoms/Checkbox";
 import { Eye } from "@/components/atoms/Eye";
 import { InfoTooltip } from "@/components/atoms/InfoTooltip";
 import ModalEmail from "@/components/molecules/ModalEmail";
-import { initialValues, registerSchema } from "@/utils/registerSchema";
+import { ValuesFormType, registerSchema, initialValues } from "@/utils/registerSchema";
 import axios from "axios";
 import { Field, Form, FormikProvider, useFormik } from "formik";
 import Image from "next/image";
@@ -22,14 +22,6 @@ import {
   TxtTerms,
 } from "./style";
 
-type ValuesFormType = {
-  name: string;
-  email: string;
-  dataBirthday: string;
-  confirmEmail: string;
-  password: string;
-  confirmPassword: string;
-};
 
 export function FormRegister() {
   const [openTermos, setOpenTermos] = useState(false);
@@ -97,6 +89,7 @@ export function FormRegister() {
     initialValues: initialValues,
     validationSchema: registerSchema,
     onSubmit: handleSubmit,
+    validateOnChange: true
   });
 
   useEffect(() => {
@@ -106,6 +99,11 @@ export function FormRegister() {
       setIsConcluidoDesabilitado(true);
     }
   }, [agree, formik.isValid, formik.touched]);
+
+
+
+
+
 
   const today = new Date();
   const yesterday = new Date();

--- a/src/utils/registerSchema.ts
+++ b/src/utils/registerSchema.ts
@@ -1,7 +1,6 @@
 import * as yup from "yup";
 
 export const registerSchema = yup.object({
-  name: yup.string().required("O nome é obrigatório"),
   email: yup
     .string()
     .email("E-mail inválido")
@@ -13,7 +12,7 @@ export const registerSchema = yup.object({
   confirmEmail: yup
     .string()
     .oneOf([yup.ref("email")], "Os campos informados não coincidem")
-    .required("Confirme seu e-mail"),
+    .required(""),
   password: yup
     .string()
     .required("A senha é obrigatória")
@@ -25,7 +24,8 @@ export const registerSchema = yup.object({
   confirmPassword: yup
     .string()
     .oneOf([yup.ref("password")], "Os campos informados não coincidem")
-    .required("Confirme a sua senha"),
+    .required(""),
+    
   dataBirthday: yup.date().required(""),
 });
 
@@ -36,4 +36,13 @@ export const initialValues = {
   confirmEmail: "",
   password: "",
   confirmPassword: "",
+};
+
+export type ValuesFormType = {
+  name: string;
+  email: string;
+  dataBirthday: string;
+  confirmEmail: string;
+  password: string;
+  confirmPassword: string;
 };


### PR DESCRIPTION
**DESCRIÇÃO DO COMMIT**

<hr>

Os erros do formulário de cadastro foram ajustados conforme  US/FIGMA.

- O erro de "Os campos informados não coincidem" abaixo do input de confirmação de email, vai aparecendo ao digitar da primeira letra, e só some após os dois campos estarem com a mesma informação.

- Foram retirados os erros de campos obrigatórios conforme a US
![image](https://github.com/SouJunior/mentores-frontend/assets/88148849/f42c396f-252f-419e-bcda-d9f855a6294d)



<hr>

**Refatoração**

- Foi transferido o type dos campos para o arquivo utils.ts