### PR TITLE
Estado de loding adicionado para o formulário de cadastro e outras correções

### DIFF
--- a/src/components/atoms/Eye/style.ts
+++ b/src/components/atoms/Eye/style.ts
@@ -7,7 +7,7 @@ export const EyeContainer = styled.button<
   border: none;
   height: 48px;
   background-color: transparent;
-  color: ${(props) => props.theme.colors.gray[400]};
+  color: ${(props) => props.theme.colors.gray[700]};
   left: ${(props) => props.left}px;
   margin-top: ${(props) => props.marginTop}px;
   cursor: pointer;

--- a/src/components/molecules/Calendar/Content.tsx
+++ b/src/components/molecules/Calendar/Content.tsx
@@ -20,7 +20,7 @@ interface CalendarWeek {
   week: number
   days: {
     date: dayjs.Dayjs
-    notCurrentMonth?: boolean
+    disabled?: boolean
   }[]
 }
 
@@ -64,10 +64,13 @@ export function Content({ onSelected, selected, ...props }: ContentProps) {
     const calendarDays = [
       ...previousMonthFillArray.map((date) => ({
         date,
-        notCurrentMonth: true,
+        disabled: true,
       })),
-      ...daysInMonthArray.map((date) => ({ date })),
-      ...nextMonthFillArray.map((date) => ({ date, notCurrentMonth: true })),
+      ...daysInMonthArray.map((date) => {
+        const isDateAfterCurrentDate = date.isAfter(dayjs())
+        return { date, disabled: isDateAfterCurrentDate }
+      }),
+      ...nextMonthFillArray.map((date) => ({ date, disabled: true })),
     ]
 
     const calendarWeeks = calendarDays.reduce<CalendarWeeks>(
@@ -99,8 +102,6 @@ export function Content({ onSelected, selected, ...props }: ContentProps) {
     setCurrentDate(nextMonthDate)
   }
 
-  const currentYear = new Date().getFullYear()
-
   return (
     <Popover.Portal>
       <Container align="start" {...props}>
@@ -109,7 +110,7 @@ export function Content({ onSelected, selected, ...props }: ContentProps) {
             <ArrowBackIosIcon />
           </LeftCalendarAction>
           <RightCalendarAction
-            disabled={currentDate.isAfter(dayjs(`${currentYear}-12`))}
+            disabled={currentDate.isAfter(dayjs())}
             onClick={handleNextMonth}
           >
             <ArrowForwardIosIcon />
@@ -131,19 +132,20 @@ export function Content({ onSelected, selected, ...props }: ContentProps) {
           <tbody>
             {calendarWeeks.map(({ days, week }) => (
               <tr key={week}>
-                {days.map(({ date, notCurrentMonth }) => (
-                  <td key={date.toString()}>
-                    <CalendarDay
-                      pressed={date.isSame(dayjs(selected))}
-                      onPressedChange={() =>
-                        onSelected && onSelected(date.toDate())
-                      }
-                      isNotCurrentMonth={notCurrentMonth ?? false}
-                    >
-                      {date.get('date')}
-                    </CalendarDay>
-                  </td>
-                ))}
+                {days.map(({ date, disabled }) => (
+                    <td key={date.toString()}>
+                      <CalendarDay
+                        pressed={date.isSame(dayjs(selected))}
+                        onPressedChange={() =>
+                          onSelected && onSelected(date.toDate())
+                        }
+                        isDisabled={disabled ?? false}
+                        disabled={date.isAfter(dayjs())}
+                      >
+                        {date.get('date')}
+                      </CalendarDay>
+                    </td>
+                  ))}
               </tr>
             ))}
           </tbody>

--- a/src/components/molecules/Calendar/styles.ts
+++ b/src/components/molecules/Calendar/styles.ts
@@ -69,7 +69,7 @@ export const CalendarTable = styled.table`
 `
 
 interface CalendarDayProps {
-  isNotCurrentMonth: boolean
+  isDisabled: boolean
 }
 
 export const CalendarDay = styled(Toggle.Root)<CalendarDayProps>`
@@ -78,18 +78,22 @@ export const CalendarDay = styled(Toggle.Root)<CalendarDayProps>`
   width: 1.1rem;
   transition: 0.3s;
   text-align: center;
-  color: ${(props) => props.isNotCurrentMonth && props.theme.colors.gray[300]};
+  color: ${(props) => props.isDisabled && props.theme.colors.gray[300]};
 
   line-height: 150%;
   padding: 0.5rem;
 
-  &:hover {
+  &:not(:disabled):hover {
     background-color: rgba(215, 217, 215, 0.3);
   }
 
   &[data-state='on'] {
     color: ${(props) => props.theme.colors.blue[500]};
     font-weight: 700;
+  }
+
+  &[data-disabled] {
+    cursor: not-allowed;
   }
 
   &:focus-visible {

--- a/src/components/molecules/FormRegister/index.tsx
+++ b/src/components/molecules/FormRegister/index.tsx
@@ -31,6 +31,7 @@ import { Calendar } from '../Calendar'
 import EventRoundedIcon from '@mui/icons-material/EventRounded'
 import dayjs from 'dayjs'
 import { AxiosError } from 'axios'
+import { useRouter } from 'next/router'
 
 export function FormRegister() {
   const [openTermos, setOpenTermos] = useState(false)
@@ -45,12 +46,13 @@ export function FormRegister() {
   const [eyeConfirm, setEyeConfirm] = useState(true)
   const [showCalendar, setShowCalendar] = useState(false)
 
+  const router = useRouter()
+
   const handleOpenTermos = () => setOpenTermos(true)
   const handleCloseTermos = () => setOpenTermos(false)
   const handleOpenPoliticas = () => setOpenPoliticas(true)
   const handleClosePoliticas = () => setOpenPoliticas(false)
   const handleModalEmail = () => setOpenEmail(true)
-  const handleModalCancel = () => setOpenModalCancel(true)
   const closeModalEmail = () => setOpenEmail(false)
   const closeModalCancel = () => setOpenModalCancel(false)
 
@@ -107,6 +109,18 @@ export function FormRegister() {
     onSubmit: handleSubmit,
     validateOnChange: true,
   })
+
+  const handleModalCancel = () => {
+    const { name, password, confirmEmail, confirmPassword, dataBirthday, email } = formik.values
+    const isSomeFieldFilled = name || password || email || dataBirthday || confirmEmail || confirmPassword
+
+    if (isSomeFieldFilled) {
+      setOpenModalCancel(true)
+      return
+    }
+
+    router.back()
+  }
 
   useEffect(() => {
     if (agree && formik.isValid && Object.keys(formik.touched).length > 0) {

--- a/src/components/molecules/FormRegister/index.tsx
+++ b/src/components/molecules/FormRegister/index.tsx
@@ -18,6 +18,7 @@ import { ModalPrivacyPolicy } from '../ModalPrivacyPolicy'
 import ModalTerms from '../ModalTerms'
 
 import {
+  ButtonLoading,
   ContainerBtn,
   ContainerForm,
   ContainerRegister,
@@ -29,6 +30,7 @@ import { api } from '@/lib/axios'
 import { Calendar } from '../Calendar'
 import EventRoundedIcon from '@mui/icons-material/EventRounded'
 import dayjs from 'dayjs'
+import { AxiosError } from 'axios'
 
 export function FormRegister() {
   const [openTermos, setOpenTermos] = useState(false)
@@ -82,10 +84,19 @@ export function FormRegister() {
         passwordConfirmation: values.confirmPassword,
         specialties: ['Frontend'],
       })
-      console.log('CADASTRADO')
       resetForm()
       handleModalEmail()
     } catch (error) {
+      if (error instanceof AxiosError) {
+        if (error?.response?.status === 400) {
+          alert(`${error?.response.status} ${error?.response.data.message[0]}`)
+          return
+        }
+  
+        alert("Ocorreu um erro na criação do mentor. Verifique a conexão de internet ou tente novamente mais tarde.")
+        return
+      }
+
       console.error(error)
     }
   }
@@ -107,11 +118,9 @@ export function FormRegister() {
 
   const yesterday = new Date()
   yesterday.setDate(yesterday.getDate() - 1)
-  const maxDate = yesterday.toISOString().split('T')[0]
 
   const hundredYearsAgo = new Date()
   hundredYearsAgo.setFullYear(hundredYearsAgo.getFullYear() - 100)
-  const minDate = hundredYearsAgo.toISOString().split('T')[0]
 
   return (
     <ContainerForm>
@@ -253,11 +262,17 @@ export function FormRegister() {
               height={730}
             />
             <ContainerBtn>
-              <Button
-                btnRole={'form'}
-                content={'Concluir'}
-                disabled={concluidoDesabilitado}
-              />
+              {formik.isSubmitting ? 
+                <ButtonLoading disabled>
+                  <span className='loader' />
+                </ButtonLoading>
+              : (
+                <Button
+                  btnRole={'form'}
+                  content={'Concluir'}
+                  disabled={concluidoDesabilitado}
+                />
+              )}
 
               <Button
                 btnRole={'form-secondary'}

--- a/src/components/molecules/FormRegister/style.ts
+++ b/src/components/molecules/FormRegister/style.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 export const ContainerForm = styled.div`
   width: 100%;
@@ -82,5 +82,61 @@ export const DatePickerContainer = styled.label`
 
   [data-placeholder] {
     color: ${(props) => props.theme.colors.gray[300]};
+  }
+`
+
+const animloader = keyframes`
+  0% {
+    transform: scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+`
+
+export const ButtonLoading = styled.button`
+  display: grid;
+  place-content: center;
+  font-size: ${(props) => props.theme.fontSizes.sm};
+  border-color: ${(props) => props.theme.colors.blue[400]};
+  color: ${(props) => props.theme.colors.white};
+  width: 100%;
+  height: 48px;
+
+  background: ${(props) => props.theme.colors.blue[400]};
+
+  &:not(:disabled):hover {
+    background-color: ${(props) => props.theme.colors.blue[700]};
+    color: ${(props) => props.theme.colors.white};
+    box-shadow: 0px 1px 15px rgba(17, 101, 186, 0.4);
+  }
+
+  &:disabled {
+    cursor: wait;
+  }
+
+  .loader {
+    width: 24px;
+    height: 24px;
+    display: inline-block;
+    position: relative;
+  } 
+  .loader::after,
+  .loader::before {
+    content: '';  
+    box-sizing: border-box;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: #FFF;
+    position: absolute;
+    left: 0;
+    top: 0;
+    animation: ${animloader} 2s linear infinite;
+  }
+  .loader::after {
+    animation-delay: 1s;
   }
 `


### PR DESCRIPTION
- Adicionei o estado de loading quando está sendo criado um mentor na plataforma, além de adicionar alertas caso aconteça algum erro.

### Correções: 

- Desabilitei os dias que vinham depois da data atual no input de calendário personalizado;
- Concertei a estilização de um componente que estava selecionando uma cor inexistente do tema, que acarretava em um erro no deploy;
-  Modal de cancelamento do formulário de cadastro estava aparecendo mesmo quando nenhum campo estava preenchido.