### PR TITLE
Returned to previous calendly configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "framer-motion": "^10.13.0",
         "next": "13.4.12",
         "react": "18.2.0",
-        "react-calendly": "^4.3.0",
         "react-dom": "18.2.0",
         "react-easy-crop": "^5.0.2",
         "react-fast-marquee": "^1.6.0",
@@ -7327,19 +7326,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-calendly": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/react-calendly/-/react-calendly-4.3.0.tgz",
-      "integrity": "sha512-JFZzYhyJBaoZDseB3UqzeOx1rbzCK24nr5pqH/6zJEh7CZ/pn5R49rkIJ0g5E7j5WQ3K7xBSgBD7WgM36v3gZw==",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "framer-motion": "^10.13.0",
     "next": "13.4.12",
     "react": "18.2.0",
-    "react-calendly": "^4.3.0",
     "react-dom": "18.2.0",
     "react-easy-crop": "^5.0.2",
     "react-fast-marquee": "^1.6.0",

--- a/src/components/atoms/CardSchedulingMentor/index.tsx
+++ b/src/components/atoms/CardSchedulingMentor/index.tsx
@@ -46,7 +46,7 @@ export default function CardScheduling({ mentor }: MentorsProps) {
         </>
       </StacksContainer>
       <ButtonsContainer>
-        <a target="_blank" href={`https://calendly.com/${mentor.calendlyName}`}>
+        <a target="_blank" href={`https://calendly.com/${mentor.calendlyName}/${mentor.agendaName}`}>
           <SchedButton disabled={!mentor.calendlyName}>
             Agendar Mentoria
           </SchedButton>

--- a/src/components/atoms/ModalSchedMentor/index.tsx
+++ b/src/components/atoms/ModalSchedMentor/index.tsx
@@ -56,7 +56,7 @@ export default function ModalSchedMentor({
           </StacksContainer>
         </SpecialityContainer>
         <AboutContainer>{mentor.aboutMe}</AboutContainer>
-        <Link href={`https://calendly.com/${mentor.calendlyName}`}>
+        <Link href={`https://calendly.com/${mentor.calendlyName}/${mentor.agendaName}`}>
           <SchedButton disabled={!mentor.calendlyName}>
             Agendar mentoria
           </SchedButton>

--- a/src/components/molecules/CardMentor/index.tsx
+++ b/src/components/molecules/CardMentor/index.tsx
@@ -50,7 +50,7 @@ export function CardMentor({ mentor }: CardMentorProps) {
       </CardStacks>
       <CardButton
         target="_blank"
-        href={`https://calendly.com/${mentor.calendlyName}`}
+        href={`https://calendly.com/${mentor.calendlyName}/${mentor.agendaName}`}
       >
         <button disabled={buttonDisabled}> Agendar um horário </button>
       </CardButton>

--- a/src/components/molecules/CardMentor/style.ts
+++ b/src/components/molecules/CardMentor/style.ts
@@ -65,7 +65,7 @@ export const CardStack = styled.div`
 `
 
 export const CardButton = styled.a`
-  display: block;
+  display: flex;
   width: 100%;
 
   button {

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
 
-const serverUrl = 'https://mentores-backend.onrender.com'
+// const serverUrl = 'https://mentores-backend.onrender.com'
+const localUrl = "http://localhost:3003"
 
 export const api = axios.create({
-  baseURL: serverUrl,
+  baseURL: localUrl,
 })

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,8 +1,8 @@
 import axios from 'axios'
 
-// const serverUrl = 'https://mentores-backend.onrender.com'
-const localUrl = "http://localhost:3003"
+const serverUrl = 'https://mentores-backend.onrender.com'
+// const localUrl = "http://localhost:3003"
 
 export const api = axios.create({
-  baseURL: localUrl,
+  baseURL: serverUrl,
 })


### PR DESCRIPTION
The source of the problem was discovered to be different. The deployed API is not returning the data correctly, in other words, when trying to test with the remote url, the calendly feature don't work correctly because of that, but does locally.